### PR TITLE
Implement selection of a single branch or author

### DIFF
--- a/package.json
+++ b/package.json
@@ -1095,6 +1095,11 @@
 					"default": false,
 					"markdownDescription": "Only follow the first parent of commits when discovering the commits to load in the Git Graph View. See [--first-parent](https://git-scm.com/docs/git-log#Documentation/git-log.txt---first-parent) to find out more about this setting. This can be overridden per repository in the Git Graph View's Repository Settings Widget."
 				},
+				"git-graph.repository.selectMultipleBranches": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enables the selection of multiple branches from the Branches dropdown."
+				},
 				"git-graph.repository.showCommitsOnlyReferencedByTags": {
 					"type": "boolean",
 					"default": true,

--- a/package.json
+++ b/package.json
@@ -1095,6 +1095,11 @@
 					"default": false,
 					"markdownDescription": "Only follow the first parent of commits when discovering the commits to load in the Git Graph View. See [--first-parent](https://git-scm.com/docs/git-log#Documentation/git-log.txt---first-parent) to find out more about this setting. This can be overridden per repository in the Git Graph View's Repository Settings Widget."
 				},
+				"git-graph.repository.selectMultipleAuthors": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enables the selection of multiple authors from the Authors dropdown."
+				},
 				"git-graph.repository.selectMultipleBranches": {
 					"type": "boolean",
 					"default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -466,6 +466,13 @@ class Config {
 	}
 
 	/**
+	 * Get the value of the `git-graph.repository.selectMultipleAuthors` Extension Setting.
+	 */
+	get selectMultipleAuthors() {
+		return !!this.config.get('repository.selectMultipleAuthors', true);
+	}
+
+	/**
 	 * Get the value of the `git-graph.repository.selectMultipleBranches` Extension Setting.
 	 */
 	get selectMultipleBranches() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -466,6 +466,13 @@ class Config {
 	}
 
 	/**
+	 * Get the value of the `git-graph.repository.selectMultipleBranches` Extension Setting.
+	 */
+	get selectMultipleBranches() {
+		return !!this.config.get('repository.selectMultipleBranches', true);
+	}
+
+	/**
 	 * Get the value of the `git-graph.repository.showCommitsOnlyReferencedByTags` Extension Setting.
 	 */
 	get showCommitsOnlyReferencedByTags() {

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -691,6 +691,7 @@ export class GitGraphView extends Disposable {
 				onRepoLoad: config.onRepoLoad,
 				referenceLabels: config.referenceLabels,
 				repoDropdownOrder: config.repoDropdownOrder,
+				selectMultipleAuthors: config.selectMultipleAuthors,
 				selectMultipleBranches: config.selectMultipleBranches,
 				showRemoteBranches: config.showRemoteBranches,
 				simplifyByDecoration: config.simplifyByDecoration,
@@ -721,6 +722,7 @@ export class GitGraphView extends Disposable {
 		} else if (numRepos > 0) {
 			const stickyClassAttr = initialState.config.stickyHeader ? ' class="sticky"' : '';
 			const branchDropdownLabel = initialState.config.selectMultipleBranches ? 'Branches' : 'Branch';
+			const authorDropdownLabel = initialState.config.selectMultipleAuthors ? 'Authors' : 'Author';
 			let hideRemotes = '', hideSimplify = '';
 			if (!config.toolbarButtonVisibility.remotes) { hideRemotes = 'style="display: none"'; }
 			if (!config.toolbarButtonVisibility.simplify) { hideSimplify = 'style="display: none"'; }
@@ -729,7 +731,7 @@ export class GitGraphView extends Disposable {
 				<div id="controls"${stickyClassAttr}>
 					<span id="repoControl"><span class="unselectable">Repo: </span><div id="repoDropdown" class="dropdown"></div></span>
 					<span id="branchControl"><span class="unselectable">${branchDropdownLabel}: </span><div id="branchDropdown" class="dropdown"></div></span>
-					<span id="authorControl"><span class="unselectable">Authors: </span><div id="authorDropdown" class="dropdown"></div></span>
+					<span id="authorControl"><span class="unselectable">${authorDropdownLabel}: </span><div id="authorDropdown" class="dropdown"></div></span>
 					<label ${hideRemotes} id="showRemoteBranchesControl" title="Show Remote Branches"><input type="checkbox" id="showRemoteBranchesCheckbox" tabindex="-1"><span class="customCheckbox"></span>Remotes</label>
 					<label ${hideSimplify} id="simplifyByDecorationControl" title="Simplify By Decoration"><input type="checkbox" id="simplifyByDecorationCheckbox" tabindex="-1"><span class="customCheckbox"></span>Simplify</label>
 					<div id="currentBtn" title="Current"></div>

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -691,6 +691,7 @@ export class GitGraphView extends Disposable {
 				onRepoLoad: config.onRepoLoad,
 				referenceLabels: config.referenceLabels,
 				repoDropdownOrder: config.repoDropdownOrder,
+				selectMultipleBranches: config.selectMultipleBranches,
 				showRemoteBranches: config.showRemoteBranches,
 				simplifyByDecoration: config.simplifyByDecoration,
 				showStashes: config.showStashes,
@@ -719,6 +720,7 @@ export class GitGraphView extends Disposable {
 			</body>`;
 		} else if (numRepos > 0) {
 			const stickyClassAttr = initialState.config.stickyHeader ? ' class="sticky"' : '';
+			const branchDropdownLabel = initialState.config.selectMultipleBranches ? 'Branches' : 'Branch';
 			let hideRemotes = '', hideSimplify = '';
 			if (!config.toolbarButtonVisibility.remotes) { hideRemotes = 'style="display: none"'; }
 			if (!config.toolbarButtonVisibility.simplify) { hideSimplify = 'style="display: none"'; }
@@ -726,7 +728,7 @@ export class GitGraphView extends Disposable {
 			<div id="view" tabindex="-1">
 				<div id="controls"${stickyClassAttr}>
 					<span id="repoControl"><span class="unselectable">Repo: </span><div id="repoDropdown" class="dropdown"></div></span>
-					<span id="branchControl"><span class="unselectable">Branches: </span><div id="branchDropdown" class="dropdown"></div></span>
+					<span id="branchControl"><span class="unselectable">${branchDropdownLabel}: </span><div id="branchDropdown" class="dropdown"></div></span>
 					<span id="authorControl"><span class="unselectable">Authors: </span><div id="authorDropdown" class="dropdown"></div></span>
 					<label ${hideRemotes} id="showRemoteBranchesControl" title="Show Remote Branches"><input type="checkbox" id="showRemoteBranchesCheckbox" tabindex="-1"><span class="customCheckbox"></span>Remotes</label>
 					<label ${hideSimplify} id="simplifyByDecorationControl" title="Simplify By Decoration"><input type="checkbox" id="simplifyByDecorationCheckbox" tabindex="-1"><span class="customCheckbox"></span>Simplify</label>

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,7 @@ export interface GitGraphViewConfig {
 	readonly onRepoLoad: OnRepoLoadConfig;
 	readonly referenceLabels: ReferenceLabelsConfig;
 	readonly repoDropdownOrder: RepoDropdownOrder;
+	readonly selectMultipleAuthors: boolean;
 	readonly selectMultipleBranches: boolean;
 	readonly showRemoteBranches: boolean;
 	readonly simplifyByDecoration: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,7 @@ export interface GitGraphViewConfig {
 	readonly onRepoLoad: OnRepoLoadConfig;
 	readonly referenceLabels: ReferenceLabelsConfig;
 	readonly repoDropdownOrder: RepoDropdownOrder;
+	readonly selectMultipleBranches: boolean;
 	readonly showRemoteBranches: boolean;
 	readonly simplifyByDecoration: boolean;
 	readonly showStashes: boolean;

--- a/web/main.ts
+++ b/web/main.ts
@@ -87,7 +87,7 @@ class GitGraphView {
 			this.loadRepo(values[0]);
 		});
 
-		this.branchDropdown = new Dropdown('branchDropdown', false, true, 'Branches', (values) => {
+		this.branchDropdown = new Dropdown('branchDropdown', false, this.config.selectMultipleBranches, 'Branches', (values) => {
 			this.currentBranches = values;
 			this.maxCommits = this.config.initialLoadCommits;
 			this.saveState();

--- a/web/main.ts
+++ b/web/main.ts
@@ -94,7 +94,7 @@ class GitGraphView {
 			this.clearCommits();
 			this.requestLoadRepoInfoAndCommits(true, true);
 		});
-		this.authorDropdown = new Dropdown('authorDropdown', false, true, 'Authors', (values) => {
+		this.authorDropdown = new Dropdown('authorDropdown', false, this.config.selectMultipleAuthors, 'Authors', (values) => {
 			this.currentAuthors = values;
 			this.maxCommits = this.config.initialLoadCommits;
 			this.saveState();


### PR DESCRIPTION
Summary of the issue:

A single branch/author cannot be selected from the drop-down with a single click.  Currently, a branch/author is added to the selection when clicked, so in order to deselect the previously selected branch/author, it has to be clicked as well.  This is annoying when one just wants to switch to another branch/author without bothering with the "multiple selection" feature.

Description outlining how this pull request resolves the issue:

Introduce `selectMultipleBranches`/`selectMultipleAuthors` settings which allow the toggling of the "multiple selection" feature for branches/authors.  When enabled, make the respective drop-down behave as before.  When disabled, restrict branch/author selection to a single entry, effectively implementing switching of branches/authors.  Enable both settings by default so that the previous behavior of the drop-downs would be preserved when using the default settings.