### PR TITLE
allow collapsing commit summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,11 @@
 					"default": "Inline",
 					"description": "Specifies where the Commit Details View is rendered in the Git Graph View."
 				},
+				"git-graph.commitDetailsView.initiallyHideCdvSummary": {
+					"type": "boolean",
+					"default": false,
+					"description": "Initially collapse Commit Summary in Commit Details View"
+				},
 				"git-graph.contextMenuActionsVisibility": {
 					"type": "object",
 					"default": {},

--- a/package.json
+++ b/package.json
@@ -138,10 +138,10 @@
 					"default": "Inline",
 					"description": "Specifies where the Commit Details View is rendered in the Git Graph View."
 				},
-				"git-graph.commitDetailsView.initiallyHideCdvSummary": {
+				"git-graph.commitDetailsView.initiallyHideSummary": {
 					"type": "boolean",
 					"default": false,
-					"description": "Initially collapse Commit Summary in Commit Details View"
+					"description": "Initially hide the commit summary in the Commit Details View."
 				},
 				"git-graph.contextMenuActionsVisibility": {
 					"type": "object",

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,7 +73,7 @@ class Config {
 			location: this.getRenamedExtensionSetting<string>('commitDetailsView.location', 'commitDetailsViewLocation', 'Inline') === 'Docked to Bottom'
 				? CommitDetailsViewLocation.DockedToBottom
 				: CommitDetailsViewLocation.Inline,
-			initiallyHideCdvSummary: this.config.get('commitDetailsView.initiallyHideCdvSummary', false)
+			initiallyHideSummary: this.config.get('commitDetailsView.initiallyHideSummary', false)
 		};
 	}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,8 @@ class Config {
 				: FileViewType.Tree,
 			location: this.getRenamedExtensionSetting<string>('commitDetailsView.location', 'commitDetailsViewLocation', 'Inline') === 'Docked to Bottom'
 				? CommitDetailsViewLocation.DockedToBottom
-				: CommitDetailsViewLocation.Inline
+				: CommitDetailsViewLocation.Inline,
+			initiallyHideCdvSummary: this.config.get('commitDetailsView.initiallyHideCdvSummary', false)
 		};
 	}
 

--- a/src/extensionState.ts
+++ b/src/extensionState.ts
@@ -37,7 +37,8 @@ export const DEFAULT_REPO_STATE: GitRepoState = {
 	simplifyByDecoration: BooleanOverride.Default,
 	showStashes: BooleanOverride.Default,
 	showTags: BooleanOverride.Default,
-	workspaceFolderIndex: null
+	workspaceFolderIndex: null,
+	isCdvSummaryHidden: true
 };
 
 const DEFAULT_GIT_GRAPH_VIEW_GLOBAL_STATE: GitGraphViewGlobalState = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,6 +288,7 @@ export interface CommitDetailsViewConfig {
 	readonly fileTreeCompactFolders: boolean;
 	readonly fileViewType: FileViewType;
 	readonly location: CommitDetailsViewLocation;
+	readonly initiallyHideCdvSummary: boolean;
 }
 
 export interface GraphConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -222,6 +222,7 @@ export interface GitRepoState {
 	showStashes: BooleanOverride;
 	showTags: BooleanOverride;
 	workspaceFolderIndex: number | null;
+	isCdvSummaryHidden: boolean;
 }
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,7 +288,7 @@ export interface CommitDetailsViewConfig {
 	readonly fileTreeCompactFolders: boolean;
 	readonly fileViewType: FileViewType;
 	readonly location: CommitDetailsViewLocation;
-	readonly initiallyHideCdvSummary: boolean;
+	readonly initiallyHideSummary: boolean;
 }
 
 export interface GraphConfig {

--- a/web/main.ts
+++ b/web/main.ts
@@ -2658,7 +2658,7 @@ class GitGraphView {
 			'</div><div class="cdvHeightResize"></div>';
 
 		elem.innerHTML = isDocked ? html : '<td><div class="cdvHeightResize"></div></td><td colspan="' + (this.getNumColumns() - 1) + '"><div id="cdvContentWrapper">' + html + '</div></td>';
-		if (!expandedCommit.loading) this.setCdvDivider();
+		this.setCdvDivider();
 		this.setCdvHeight(elem, isDocked);
 		if (!isDocked) this.renderGraph();
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -2777,11 +2777,16 @@ class GitGraphView {
 		}
 	}
 
-	private hideCdvSummary(hidden: boolean) {
+	private hideCdvSummary(hide: boolean) {
 		let btn = document.getElementById('cdvSummaryToggleBtn');
-		if (hidden) {
+		let cdvSummary = document.getElementById('cdvSummary');
+		if (hide) {
 			btn!.classList.add('flipHorizontal');
-		} else btn!.classList.remove('flipHorizontal');
+			cdvSummary!.classList.add('hidden');
+		} else {
+			btn!.classList.remove('flipHorizontal');
+			cdvSummary!.classList.remove('hidden');
+		}
 	}
 
 	private setCdvHeight(elem: HTMLElement, isDocked: boolean) {
@@ -2823,7 +2828,7 @@ class GitGraphView {
 				this.gitRepos[this.currentRepo].cdvHeight = height;
 				let elem = document.getElementById('cdv');
 				if (elem !== null) this.setCdvHeight(elem, isDocked);
-				if (!isDocked) this.renderGraph();
+				//if (!isDocked) this.renderGraph();
 			}
 		};
 		const stopResizingCdvHeight: EventListener = (e) => {

--- a/web/main.ts
+++ b/web/main.ts
@@ -184,6 +184,7 @@ class GitGraphView {
 				name: this.gitRepos[this.currentRepo].name || getRepoName(this.currentRepo)
 			}, 'Opening Terminal');
 		});
+		this.gitRepos[this.currentRepo].isCdvSummaryHidden = this.config.commitDetailsView.initiallyHideCdvSummary;
 	}
 
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -184,7 +184,7 @@ class GitGraphView {
 				name: this.gitRepos[this.currentRepo].name || getRepoName(this.currentRepo)
 			}, 'Opening Terminal');
 		});
-		this.gitRepos[this.currentRepo].isCdvSummaryHidden = this.config.commitDetailsView.initiallyHideCdvSummary;
+		this.gitRepos[this.currentRepo].isCdvSummaryHidden = this.config.commitDetailsView.initiallyHideSummary;
 	}
 
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -2609,7 +2609,7 @@ class GitGraphView {
 		}
 
 		if (expandedCommit.loading) {
-			html += '<div id="cdvLoading">' + SVG_ICONS.loading + ' Loading ' + (expandedCommit.compareWithHash === null ? expandedCommit.commitHash !== UNCOMMITTED ? 'Commit Details' : 'Uncommitted Changes' : 'Commit Comparison') + ' ...</div>';
+			html += '<div id="cdvFiles"></div><div id="cdvLoading">' + SVG_ICONS.loading + ' Loading ' + (expandedCommit.compareWithHash === null ? expandedCommit.commitHash !== UNCOMMITTED ? 'Commit Details' : 'Uncommitted Changes' : 'Commit Comparison') + ' ...</div>';
 		} else {
 			html += '<div id="cdvSummary">';
 			if (expandedCommit.compareWithHash === null) {

--- a/web/main.ts
+++ b/web/main.ts
@@ -2785,10 +2785,10 @@ class GitGraphView {
 		let btnIcon = document.getElementById('cdvSummaryToggleBtn')?.getElementsByTagName('svg')?.[0] ?? null;
 		let cdvSummary = document.getElementById('cdvSummary');
 		if (hide && !this.isCdvDocked()) {
-			if (btnIcon) btnIcon.style.transform = 'rotate(-90deg)';
+			if (btnIcon) btnIcon.style.transform = 'rotate(90deg)';
 			cdvSummary!.classList.add('hidden');
 		} else {
-			if (btnIcon) btnIcon.style.transform = 'rotate(90deg)';
+			if (btnIcon) btnIcon.style.transform = 'rotate(-90deg)';
 			cdvSummary!.classList.remove('hidden');
 		}
 		let elem = document.getElementById('cdv');

--- a/web/main.ts
+++ b/web/main.ts
@@ -2648,7 +2648,7 @@ class GitGraphView {
 				// Commit comparison should be shown
 				html += 'Displaying all changes from <b>' + commitOrder.from + '</b> to <b>' + (commitOrder.to !== UNCOMMITTED ? commitOrder.to : 'Uncommitted Changes') + '</b>.';
 			}
-			html += '</div><div id="cdvFiles">' + generateFileViewHtml(expandedCommit.fileTree!, expandedCommit.fileChanges!, expandedCommit.lastViewedFile, expandedCommit.contextMenuOpen.fileView, this.getFileViewType(), commitOrder.to === UNCOMMITTED) + '</div><div id="cdvDivider"></div>';
+			html += '</div><div id="cdvFiles"><div id="cdvSummaryToggleBtn">' + SVG_ICONS.collapse + '</div><div id="cdvFilesView">' + generateFileViewHtml(expandedCommit.fileTree!, expandedCommit.fileChanges!, expandedCommit.lastViewedFile, expandedCommit.contextMenuOpen.fileView, this.getFileViewType(), commitOrder.to === UNCOMMITTED) + '</div></div><div id="cdvDivider"></div>';
 		}
 		html += '</div><div id="cdvControls"><div id="cdvClose" class="cdvControlBtn" title="Close">' + SVG_ICONS.close + '</div>' +
 			(codeReviewPossible ? '<div id="cdvCodeReview" class="cdvControlBtn">' + SVG_ICONS.review + '</div>' : '') +
@@ -2730,6 +2730,10 @@ class GitGraphView {
 			document.getElementById('cdvExpand')!.addEventListener('click', () => {
 				this.openFolders(true);
 			});
+			document.getElementById('cdvSummaryToggleBtn')!.addEventListener('click', () => {
+				this.gitRepos[this.currentRepo].isCdvSummaryHidden = !(this.gitRepos[this.currentRepo].isCdvSummaryHidden);
+				this.hideCdvSummary(this.gitRepos[this.currentRepo].isCdvSummaryHidden);
+			});
 
 			if (codeReviewPossible) {
 				this.renderCodeReviewBtn();
@@ -2771,6 +2775,13 @@ class GitGraphView {
 				});
 			}
 		}
+	}
+
+	private hideCdvSummary(hidden: boolean) {
+		let btn = document.getElementById('cdvSummaryToggleBtn');
+		if (hidden) {
+			btn!.classList.add('flipHorizontal');
+		} else btn!.classList.remove('flipHorizontal');
 	}
 
 	private setCdvHeight(elem: HTMLElement, isDocked: boolean) {

--- a/web/main.ts
+++ b/web/main.ts
@@ -2782,13 +2782,13 @@ class GitGraphView {
 	}
 
 	private hideCdvSummary(hide: boolean) {
-		let btn = document.getElementById('cdvSummaryToggleBtn');
+		let btnIcon = document.getElementById('cdvSummaryToggleBtn')?.getElementsByTagName('svg')?.[0] ?? null;
 		let cdvSummary = document.getElementById('cdvSummary');
 		if (hide && !this.isCdvDocked()) {
-			if (btn) btn.classList.add('flipHorizontal');
+			if (btnIcon) btnIcon.style.transform = 'rotate(-90deg)';
 			cdvSummary!.classList.add('hidden');
 		} else {
-			if (btn) btn!.classList.remove('flipHorizontal');
+			if (btnIcon) btnIcon.style.transform = 'rotate(90deg)';
 			cdvSummary!.classList.remove('hidden');
 		}
 		let elem = document.getElementById('cdv');

--- a/web/main.ts
+++ b/web/main.ts
@@ -2648,7 +2648,7 @@ class GitGraphView {
 				// Commit comparison should be shown
 				html += 'Displaying all changes from <b>' + commitOrder.from + '</b> to <b>' + (commitOrder.to !== UNCOMMITTED ? commitOrder.to : 'Uncommitted Changes') + '</b>.';
 			}
-			html += '</div><div id="cdvFiles"><div id="cdvSummaryToggleBtn">' + SVG_ICONS.collapse + '</div><div id="cdvFilesViewWrapper"><div id="cdvFilesView">' + generateFileViewHtml(expandedCommit.fileTree!, expandedCommit.fileChanges!, expandedCommit.lastViewedFile, expandedCommit.contextMenuOpen.fileView, this.getFileViewType(), commitOrder.to === UNCOMMITTED) + '</div></div></div><div id="cdvDivider"></div>';
+			html += '</div><div id="cdvFiles">' + (!isDocked ? '<div id="cdvSummaryToggleBtn">' + SVG_ICONS.collapse + '</div>' : '') + '<div id="cdvFilesViewWrapper"><div id="cdvFilesView">' + generateFileViewHtml(expandedCommit.fileTree!, expandedCommit.fileChanges!, expandedCommit.lastViewedFile, expandedCommit.contextMenuOpen.fileView, this.getFileViewType(), commitOrder.to === UNCOMMITTED) + '</div></div></div><div id="cdvDivider"></div>';
 		}
 		html += '</div><div id="cdvControls"><div id="cdvClose" class="cdvControlBtn" title="Close">' + SVG_ICONS.close + '</div>' +
 			(codeReviewPossible ? '<div id="cdvCodeReview" class="cdvControlBtn">' + SVG_ICONS.review + '</div>' : '') +
@@ -2731,7 +2731,8 @@ class GitGraphView {
 			document.getElementById('cdvExpand')!.addEventListener('click', () => {
 				this.openFolders(true);
 			});
-			document.getElementById('cdvSummaryToggleBtn')!.addEventListener('click', () => {
+			let cdvSummaryToggleBtn = document.getElementById('cdvSummaryToggleBtn');
+			if (cdvSummaryToggleBtn !== null) cdvSummaryToggleBtn.addEventListener('click', () => {
 				this.gitRepos[this.currentRepo].isCdvSummaryHidden = !(this.gitRepos[this.currentRepo].isCdvSummaryHidden);
 				this.hideCdvSummary(this.gitRepos[this.currentRepo].isCdvSummaryHidden);
 			});
@@ -2782,11 +2783,11 @@ class GitGraphView {
 	private hideCdvSummary(hide: boolean) {
 		let btn = document.getElementById('cdvSummaryToggleBtn');
 		let cdvSummary = document.getElementById('cdvSummary');
-		if (hide) {
-			btn!.classList.add('flipHorizontal');
+		if (hide && !this.isCdvDocked()) {
+			if (btn) btn.classList.add('flipHorizontal');
 			cdvSummary!.classList.add('hidden');
 		} else {
-			btn!.classList.remove('flipHorizontal');
+			if (btn) btn!.classList.remove('flipHorizontal');
 			cdvSummary!.classList.remove('hidden');
 		}
 		let elem = document.getElementById('cdv');

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -483,14 +483,13 @@ table { border-collapse: collapse; }
 	padding:2px;
 	width:16px;
 	height:16px;
-    background-color: color-mix(in srgb, var(--vscode-editor-background) 90%, rgba(128, 128, 128,1));}
+    background-color: color-mix(in srgb, var(--vscode-editor-background) 90%, rgba(128, 128, 128,1));
+	border-left: 1px solid var(--vscode-editor-background);
+}
 
 #cdvSummaryToggleBtn svg{
 	fill:var(--vscode-editor-foreground);
 	fill-opacity:0.6;
-}
-.flipHorizontal{
-	transform: rotate(180deg);
 }
 .hidden{
 	display: none;

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -554,7 +554,7 @@ table { border-collapse: collapse; }
 	line-height:24px;
 	text-overflow:ellipsis;
 	opacity: 0;
-  	animation: fadeIn 1.5s ease-in-out 1s forwards;
+  	animation: fadeIn 0.25s ease-in-out 1s forwards;
 }
 @keyframes fadeIn {
 	0% {

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -311,6 +311,7 @@ table { border-collapse: collapse; }
 	font-size:13px;
 	line-height:18px;
 	white-space:normal;
+	overflow: visible;
 }
 #cdv.docked{
 	display:block;
@@ -417,6 +418,7 @@ table { border-collapse: collapse; }
 	left:0;
 	width:50%;
 	padding:10px;
+	padding-right:16px;
 	text-overflow:ellipsis;
 	-webkit-user-select:text;
 	user-select:text;
@@ -491,20 +493,35 @@ table { border-collapse: collapse; }
 	transform: rotate(180deg);
 }
 .hidden{
-	visibility:hidden;
+	display: none;
+}
+#cdvContentWrapper {
+	position: absolute;
+    left: 0;
+    right: 0;
+	top:0;
+	bottom:0;
+    z-index: 100;
+	pointer-events: none;
+
+}
+#cdvContent *, #cdvControls, .cdvHeightResize {
+    pointer-events: auto;
 }
 #cdvFiles{
 	left:50%;
 	right:0;
-	padding:4px 8px 8px 0;
 	-webkit-user-select:none;
 	user-select:none;
 	overflow: visible;
 }
-#cdvFilesView{
+#cdvFilesViewWrapper{
 	overflow-x:hidden;
 	overflow-y:auto;
 	height: 100%;
+}
+#cdvFilesView{
+	padding:4px 8px 8px 0;
 }
 #cdvFilesView ul{
 	list-style-type:none;

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -334,6 +334,7 @@ table { border-collapse: collapse; }
 	position:absolute;
 	right:0;
 	width:32px;
+	overflow: hidden;
 }
 
 .cdvControlBtn{
@@ -397,10 +398,15 @@ table { border-collapse: collapse; }
 	top:0;
 	bottom:0;
 	box-sizing:border-box;
-	border-right:1px solid rgba(128,128,128,0.2);
 	overflow-x:hidden;
 	overflow-y:auto;
 }
+#cdvSummary, #cdvFiles, #cdvLoading, #cdvControls {
+	background-color: color-mix(in srgb, var(--vscode-editor-background) 90%, rgba(128, 128, 128,1));
+	border-left:1px solid rgba(128,128,128,0.2);
+	border-bottom:2px solid rgba(128,128,128,0.2);
+}
+
 #cdvDivider{
 	position:absolute;
 	left:50%;
@@ -484,6 +490,9 @@ table { border-collapse: collapse; }
 .flipHorizontal{
 	transform: rotate(180deg);
 }
+.hidden{
+	visibility:hidden;
+}
 #cdvFiles{
 	left:50%;
 	right:0;
@@ -551,16 +560,13 @@ table { border-collapse: collapse; }
 	top:0;
 	bottom:2px;
 }
-#cdv.inline #cdvContent{
-	border-left:1px solid rgba(128,128,128,0.2);
-}
+
 #cdv.inline #cdvDivider{
 	top:0;
 	bottom:6px;
 }
 #cdv.inline .cdvHeightResize{
 	bottom:0;
-	border-bottom:2px solid rgba(128,128,128,0.2);
 }
 
 #cdv.docked #cdvContent, #cdv.docked #cdvControls{

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -553,7 +553,18 @@ table { border-collapse: collapse; }
 	text-align:center;
 	line-height:24px;
 	text-overflow:ellipsis;
+	opacity: 0;
+  	animation: fadeIn 1.5s ease-in-out 1s forwards;
 }
+@keyframes fadeIn {
+	0% {
+	  opacity: 0;
+	}
+	100% {
+	  opacity: 1;
+	}
+}
+
 #cdvLoading svg{
 	display:inline-block;
 	width:15px !important;

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -464,15 +464,40 @@ table { border-collapse: collapse; }
 	fill:#e00000;
 	opacity:0.8;
 }
+#cdvSummaryToggleBtn{
+	position: absolute;
+	top:0;
+	margin:0;
+	left:-21px;
+	z-index:100;
+	overflow:visible;
+	cursor:pointer;
+	padding:2px;
+	width:16px;
+	height:16px;
+    background-color: color-mix(in srgb, var(--vscode-editor-background) 90%, rgba(128, 128, 128,1));}
 
+#cdvSummaryToggleBtn svg{
+	fill:var(--vscode-editor-foreground);
+	fill-opacity:0.6;
+}
+.flipHorizontal{
+	transform: rotate(180deg);
+}
 #cdvFiles{
 	left:50%;
 	right:0;
 	padding:4px 8px 8px 0;
 	-webkit-user-select:none;
 	user-select:none;
+	overflow: visible;
 }
-#cdvFiles ul{
+#cdvFilesView{
+	overflow-x:hidden;
+	overflow-y:auto;
+	height: 100%;
+}
+#cdvFilesView ul{
 	list-style-type:none;
 	-webkit-margin-before:0;
 	-webkit-margin-after:0;
@@ -482,11 +507,11 @@ table { border-collapse: collapse; }
 	margin:0;
 	padding:0 0 0 25px;
 }
-#cdvFiles > ul{
+#cdvFilesView > ul{
 	-webkit-padding-start:10px;
 	padding:0 0 0 10px;
 }
-#cdvFiles li{
+#cdvFilesView li{
 	margin-top:4px;
 	white-space:nowrap;
 	text-overflow:ellipsis;

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -501,7 +501,7 @@ table { border-collapse: collapse; }
     right: 0;
 	top:0;
 	bottom:0;
-    z-index: 100;
+    z-index: 11;
 	pointer-events: none;
 
 }

--- a/web/utils.ts
+++ b/web/utils.ts
@@ -45,7 +45,8 @@ const SVG_ICONS = {
 
 	// The SVG icons below are from  https://github.com/microsoft/vscode-icons
 	collapseAll: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 9H4V10H9V9Z" fill="#C5C5C5"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 3L6 2H13L14 3V10L13 11H11V13L10 14H3L2 13V6L3 5H5V3ZM6 5H10L11 6V10H13V3H6V5ZM10 6H3V13H10V6Z" fill="#C5C5C5"/></svg>',
-	expandAll: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 9H4V10H9V9Z" fill="#C5C5C5"/><path d="M7 12L7 7L6 7L6 12L7 12Z" fill="#C5C5C5"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 3L6 2H13L14 3V10L13 11H11V13L10 14H3L2 13V6L3 5H5V3ZM6 5H10L11 6V10H13V3H6V5ZM10 6H3V13H10V6Z" fill="#C5C5C5"/></svg>'
+	expandAll: '<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9 9H4V10H9V9Z" fill="#C5C5C5"/><path d="M7 12L7 7L6 7L6 12L7 12Z" fill="#C5C5C5"/><path fill-rule="evenodd" clip-rule="evenodd" d="M5 3L6 2H13L14 3V10L13 11H11V13L10 14H3L2 13V6L3 5H5V3ZM6 5H10L11 6V10H13V3H6V5ZM10 6H3V13H10V6Z" fill="#C5C5C5"/></svg>',
+	collapse: '<svg style="transform: rotate(-90deg);" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd"  d="M14.207 1.707L13.5 1L7.49997 7L1.49997 1L0.792969 1.707L7.14597 8.061H7.85397L14.207 1.707ZM14.207 7.70688L13.5 6.99988L7.49997 12.9999L1.49997 6.99988L0.792969 7.70688L7.14597 14.0609H7.85397L14.207 7.70688Z"/></svg>'
 };
 
 const GIT_FILE_CHANGE_TYPES = { 'A': 'Added', 'M': 'Modified', 'D': 'Deleted', 'R': 'Renamed', 'U': 'Untracked' };


### PR DESCRIPTION
### Collapse Commit Summary in Commit Detail View
- allows collapsing commit summary in inline mode
- set initial collapse setting with `git-graph.commitDetailsView.initiallyHideCdvSummary`
- this solves hansu#3
![CollapseCdvSummary](https://github.com/user-attachments/assets/5304c31e-409d-4f96-8e7f-a2601a9de199)
