### PR TITLE
46 Fix commit summary always hides when switching focus

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,11 +138,6 @@
 					"default": "Inline",
 					"description": "Specifies where the Commit Details View is rendered in the Git Graph View."
 				},
-				"git-graph.commitDetailsView.initiallyHideSummary": {
-					"type": "boolean",
-					"default": false,
-					"description": "Initially hide the commit summary in the Commit Details View."
-				},
 				"git-graph.contextMenuActionsVisibility": {
 					"type": "object",
 					"default": {},

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,8 +72,7 @@ class Config {
 				: FileViewType.Tree,
 			location: this.getRenamedExtensionSetting<string>('commitDetailsView.location', 'commitDetailsViewLocation', 'Inline') === 'Docked to Bottom'
 				? CommitDetailsViewLocation.DockedToBottom
-				: CommitDetailsViewLocation.Inline,
-			initiallyHideSummary: this.config.get('commitDetailsView.initiallyHideSummary', false)
+				: CommitDetailsViewLocation.Inline
 		};
 	}
 

--- a/src/extensionState.ts
+++ b/src/extensionState.ts
@@ -38,7 +38,7 @@ export const DEFAULT_REPO_STATE: GitRepoState = {
 	showStashes: BooleanOverride.Default,
 	showTags: BooleanOverride.Default,
 	workspaceFolderIndex: null,
-	isCdvSummaryHidden: true
+	isCdvSummaryHidden: false
 };
 
 const DEFAULT_GIT_GRAPH_VIEW_GLOBAL_STATE: GitGraphViewGlobalState = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,7 +288,6 @@ export interface CommitDetailsViewConfig {
 	readonly fileTreeCompactFolders: boolean;
 	readonly fileViewType: FileViewType;
 	readonly location: CommitDetailsViewLocation;
-	readonly initiallyHideSummary: boolean;
 }
 
 export interface GraphConfig {

--- a/web/main.ts
+++ b/web/main.ts
@@ -2735,6 +2735,7 @@ class GitGraphView {
 			let cdvSummaryToggleBtn = document.getElementById('cdvSummaryToggleBtn');
 			if (cdvSummaryToggleBtn !== null) cdvSummaryToggleBtn.addEventListener('click', () => {
 				this.gitRepos[this.currentRepo].isCdvSummaryHidden = !(this.gitRepos[this.currentRepo].isCdvSummaryHidden);
+				this.saveRepoState();
 				this.hideCdvSummary(this.gitRepos[this.currentRepo].isCdvSummaryHidden);
 			});
 			this.hideCdvSummary(this.gitRepos[this.currentRepo].isCdvSummaryHidden);

--- a/web/main.ts
+++ b/web/main.ts
@@ -184,7 +184,6 @@ class GitGraphView {
 				name: this.gitRepos[this.currentRepo].name || getRepoName(this.currentRepo)
 			}, 'Opening Terminal');
 		});
-		this.gitRepos[this.currentRepo].isCdvSummaryHidden = this.config.commitDetailsView.initiallyHideSummary;
 	}
 
 


### PR DESCRIPTION
solves https://github.com/hansu/vscode-git-graph/issues/46

### Issue
- the commit summary always hides when switching focus

### Solution
- the `isCdvSummaryHidden` state was not saved
