### PR TITLE
fix: authors dropbox over button "Current"

### DIFF
--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -956,7 +956,7 @@ body.tagLabelsRightAligned .gitRef.tag{
 }
 
 #controls.fetchSupported{
-	padding-right:162px;
+	padding-right:180px;
 }
 #controls.fetchSupported #currentBtn{
 	right:160px;


### PR DESCRIPTION
Visual bug, in the screenshots before and after the fix

_before_
<img width="874" alt="Screenshot 2025-04-23 at 12 30 16" src="https://github.com/user-attachments/assets/d07e2fd2-8ffe-4de0-a289-dc6b592d0259" />

  
_after_
<img width="898" alt="Screenshot 2025-04-23 at 12 35 03" src="https://github.com/user-attachments/assets/03b169b4-8d8f-497c-9a28-0a46dc289b9b" />
