### PR TITLE
fix double click to select all authors in dropdown

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -237,7 +237,7 @@ class GitGraphView {
 		this.gitStashes = [];
 		this.gitTags = [];
 		this.currentBranches = null;
-		this.currentAuthors = null;
+		this.currentAuthors = [];
 		this.renderFetchButton();
 		this.closeCommitDetails(false);
 		this.settingsWidget.close();


### PR DESCRIPTION
Fix double click on 'All' in branches/author drop down.

This bug was introduced when fixing #49 :upside_down_face: .

