### PR TITLE
fix: hide commit msg box button over avatar

### DIFF
--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -476,7 +476,7 @@ table { border-collapse: collapse; }
 	position: absolute;
 	top:0;
 	margin:0;
-	left:-21px;
+	left:-13px;
 	z-index:100;
 	overflow:visible;
 	cursor:pointer;
@@ -484,7 +484,9 @@ table { border-collapse: collapse; }
 	width:16px;
 	height:16px;
     background-color: color-mix(in srgb, var(--vscode-editor-background) 90%, rgba(128, 128, 128,1));
-	border-left: 1px solid var(--vscode-editor-background);
+	border-left:1px solid rgba(128,128,128,0.2);
+	border-bottom:1px solid rgba(128,128,128,0.2);
+	border-right:1px solid rgba(128,128,128,0.2);
 }
 
 #cdvSummaryToggleBtn svg{


### PR DESCRIPTION
The button overlapped the avatar photo, so I moved it to the right
<img width="199" alt="Screenshot 2025-04-26 at 14 58 50" src="https://github.com/user-attachments/assets/d649a32d-7e0b-4ae7-99d7-986c9203b53d" />


You can see the result of the fix in the screenshot below
<img width="257" alt="Screenshot 2025-04-26 at 14 45 00" src="https://github.com/user-attachments/assets/4eedddce-3981-46bb-b070-967792596074" />
