### PR TITLE
feat: add commitDetailsView.autoScroll setting to control auto-scrolling (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Detailed information of all Git Graph settings is available [here](https://githu
 A summary of the Git Graph extension settings are:
 * **Commit Details View**:
     * **Auto Center**: Automatically center the Commit Details View when it is opened.
+    * **Auto Scroll**: Automatically scroll the view to show the commit when opening the Commit Details View.
     * **File View**:
         * **File Tree**:
             * **Compact Folders**: Render the File Tree in the Commit Details View in a compacted form, such that folders with a single child folder are compressed into a single combined folder element.

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
 					"default": true,
 					"description": "Automatically center the Commit Details View when it is opened."
 				},
+				"git-graph.commitDetailsView.autoScroll": {
+					"type": "boolean",
+					"default": true,
+					"description": "Automatically scroll the view to show the commit when opening the Commit Details View."
+				},
 				"git-graph.commitDetailsView.fileView.fileTree.compactFolders": {
 					"type": "boolean",
 					"default": true,

--- a/src/baseGitGraphView.ts
+++ b/src/baseGitGraphView.ts
@@ -84,7 +84,12 @@ export abstract class BaseGitGraphView extends Disposable {
 					this.respondLoadRepos(event.repos, loadViewTo);
 				}
 			}),
-
+			// Refresh the webview when autoScroll configuration changes so it takes effect immediately
+			vscode.workspace.onDidChangeConfiguration((e) => {
+				if (e.affectsConfiguration('git-graph.commitDetailsView.autoScroll')) {
+					this.update();
+				}
+			}),
 			// Subscribe to events triggered when an avatar is available
 			this.avatarManager.onAvatar((event) => {
 				this.sendMessage({

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,7 @@ class Config {
 	get commitDetailsView(): CommitDetailsViewConfig {
 		return {
 			autoCenter: !!this.getRenamedExtensionSetting('commitDetailsView.autoCenter', 'autoCenterCommitDetailsView', true),
+			autoScroll: !!this.config.get<boolean>('commitDetailsView.autoScroll', true),
 			fileTreeCompactFolders: !!this.getRenamedExtensionSetting('commitDetailsView.fileView.fileTree.compactFolders', 'commitDetailsViewFileTreeCompactFolders', true),
 			fileViewType: this.getRenamedExtensionSetting<string>('commitDetailsView.fileView.type', 'defaultFileViewType', 'File Tree') === 'File List'
 				? FileViewType.List

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,6 +287,7 @@ export interface GitGraphViewWorkspaceState {
 
 export interface CommitDetailsViewConfig {
 	readonly autoCenter: boolean;
+	readonly autoScroll: boolean;
 	readonly fileTreeCompactFolders: boolean;
 	readonly fileViewType: FileViewType;
 	readonly location: CommitDetailsViewLocation;
@@ -345,6 +346,7 @@ export const enum CommitDetailsViewLocation {
 	Inline,
 	DockedToBottom
 }
+
 
 export const enum CommitOrdering {
 	Date = 'date',

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -250,6 +250,25 @@ describe('Config', () => {
 				expect(value).toBe(CommitDetailsViewLocation.Inline);
 			});
 		});
+
+		describe('autoScroll', () => {
+			it('Should return true by default when the configuration value is unknown', () => {
+				const value = config.commitDetailsView.autoScroll;
+				expect(value).toBe(true);
+			});
+
+			it('Should return false when the configuration value is false', () => {
+				vscode.mockExtensionSettingReturnValue('commitDetailsView.autoScroll', false);
+				const value = config.commitDetailsView.autoScroll;
+				expect(value).toBe(false);
+			});
+
+			it('Should return true when the configuration value is true', () => {
+				vscode.mockExtensionSettingReturnValue('commitDetailsView.autoScroll', true);
+				const value = config.commitDetailsView.autoScroll;
+				expect(value).toBe(true);
+			});
+		});
 	});
 
 	describe('contextMenuActionsVisibility', () => {

--- a/web/main.ts
+++ b/web/main.ts
@@ -3035,17 +3035,23 @@ class GitGraphView {
 
 		if (!refresh) {
 			if (isDocked) {
-				let elemTop = this.controlsElem.clientHeight + expandedCommit.commitElem.offsetTop;
-				if (elemTop - 8 < this.viewElem.scrollTop) {
-					// Commit is above what is visible on screen
-					this.viewElem.scroll(0, elemTop - 8);
-				} else if (elemTop - this.viewElem.clientHeight + 32 > this.viewElem.scrollTop) {
-					// Commit is below what is visible on screen
-					this.viewElem.scroll(0, elemTop - this.viewElem.clientHeight + 32);
+				if (!this.config.commitDetailsView.autoScroll) {
+					// Do not auto-scroll when opening details (docked)
+				} else {
+					let elemTop = this.controlsElem.clientHeight + expandedCommit.commitElem.offsetTop;
+					if (elemTop - 8 < this.viewElem.scrollTop) {
+						// Commit is above what is visible on screen
+						this.viewElem.scroll(0, elemTop - 8);
+					} else if (elemTop - this.viewElem.clientHeight + 32 > this.viewElem.scrollTop) {
+						// Commit is below what is visible on screen
+						this.viewElem.scroll(0, elemTop - this.viewElem.clientHeight + 32);
+					}
 				}
 			} else {
 				let elemTop = this.controlsElem.clientHeight + elem.offsetTop, cdvHeight = this.gitRepos[this.currentRepo].cdvHeight;
-				if (this.config.commitDetailsView.autoCenter) {
+				if (!this.config.commitDetailsView.autoScroll) {
+					// Do not auto-scroll when opening details (inline)
+				} else if (this.config.commitDetailsView.autoCenter) {
 					// Center Commit Detail View setting is enabled
 					// elemTop - commit height [24px] + (commit details view height + commit height [24px]) / 2 - (view height) / 2
 					this.viewElem.scroll(0, elemTop - 12 + (cdvHeight - this.viewElem.clientHeight) / 2);


### PR DESCRIPTION
Issue Number / Link: https://github.com/hansu/vscode-git-graph/issues/63

Summary of the issue:
introduces a new setting to control auto-scrolling behavior when opening the Commit Details View in the Git Graph extension. The setting allows users to choose between "always" or "never" auto-scroll, and ensures that changes to this configuration take effect immediately.

Description outlining how this pull request resolves the issue:
<img width="1341" height="990" alt="image" src="https://github.com/user-attachments/assets/8272d51b-c23e-4d14-b515-453fe304db94" />
