### PR TITLE
Fix scroll issue in file list

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -3112,7 +3112,7 @@ class GitGraphView {
 				}
 			}, () => this.saveState());
 
-			observeElemScroll('cdvFilesView', expandedCommit.scrollTop.fileView, (scrollTop) => {
+			observeElemScroll('cdvFilesViewWrapper', expandedCommit.scrollTop.fileView, (scrollTop) => {
 				if (this.expandedCommit === null) return;
 				this.expandedCommit.scrollTop.fileView = scrollTop;
 				if (this.expandedCommit.contextMenuOpen.fileView > -1) {


### PR DESCRIPTION
**Summary of the issue:**

This fix resolves an issue with the list of files in commit details. If you scroll down this list and then switch tabs, then when the tab goes back the scroll position is reset to 0. This is very annoying when you are browsing through modified files.

**Description outlining how this pull request resolves the issue:**

This fix simply uses the correct HTML element that receives scroll events.